### PR TITLE
chore: remove latest and canary version tags

### DIFF
--- a/app/components/Navbar.vue
+++ b/app/components/Navbar.vue
@@ -42,8 +42,7 @@ const { data: versions } = useAsyncData(
 
     <div flex="~ center" gap1>
       <select v-model="currentVersion" border rounded p1 text-sm>
-        <option value="latest">Latest</option>
-        <option value="canary">Canary</option>
+        <option v-if="versions?.length" :value="versions[0]">Latest</option>
         <option
           v-for="version of versions?.slice(0, 40)"
           :key="version"

--- a/app/components/Navbar.vue
+++ b/app/components/Navbar.vue
@@ -42,7 +42,6 @@ const { data: versions } = useAsyncData(
 
     <div flex="~ center" gap1>
       <select v-model="currentVersion" border rounded p1 text-sm>
-        <option v-if="versions?.length" :value="versions[0]">Latest</option>
         <option
           v-for="version of versions?.slice(0, 40)"
           :key="version"


### PR DESCRIPTION
It was likely caused by the CDN caching the previous faulty version under the latest tag. 
<img width="1731" height="250" alt="image" src="https://github.com/user-attachments/assets/05ac05a7-4a95-41d3-bc1a-0b16195faf62" />
