### PR TITLE
fix: set max-height to warning output container

### DIFF
--- a/app/components/OutputContainer.vue
+++ b/app/components/OutputContainer.vue
@@ -132,7 +132,7 @@ const errorText = computed(() => {
     <div
       v-if="status === 'success' && data?.warnings?.length"
       overflow-x-auto
-      max-h-50%
+      max-h="50%"
       whitespace-pre
       pb4
       text-sm


### PR DESCRIPTION
Before
<img width="1468" height="794" alt="スクリーンショット 2025-08-05 17 17 50" src="https://github.com/user-attachments/assets/7d0cefd9-73a9-4ace-a4e8-8ec41a893566" />
After
<img width="1470" height="796" alt="スクリーンショット 2025-08-05 17 18 51" src="https://github.com/user-attachments/assets/a5e73ca1-edb5-4c9a-a54e-e3eea12b2d7b" />

