### PR TITLE
feat: allow using local rolldown for development

### DIFF
--- a/app/components/OutputContainer.vue
+++ b/app/components/OutputContainer.vue
@@ -27,20 +27,30 @@ const { data, status, error, refresh } = useAsyncData(
 
     loadingPhase.value = 'loading'
 
-    const [core, experimental, plugins, binding] = await Promise.all([
-      import(
-        /* @vite-ignore */ `/api/proxy/@${version}/dist/index.browser.mjs`
-      ) as Promise<typeof import('@rolldown/browser')>,
-      import(
-        /* @vite-ignore */ `/api/proxy/@${version}/dist/experimental-index.browser.mjs`
-      ) as Promise<typeof import('@rolldown/browser/experimental')>,
-      import(
-        /* @vite-ignore */ `/api/proxy/@${version}/dist/plugins-index.browser.mjs`
-      ).catch(() => null),
-      import(
-        /* @vite-ignore */ `/api/proxy/@${version}/dist/rolldown-binding.wasi-browser.js`
-      ),
-    ])
+    const [core, experimental, plugins, binding] = await Promise.all(
+      import.meta.env.VITE_USE_LOCAL_ROLLDOWN
+        ? [
+            import('@rolldown/browser'),
+            import('@rolldown/browser/experimental'),
+            import('@rolldown/browser/plugins').catch(() => null),
+            // @ts-expect-error Custom alias
+            import('@rolldown/browser/rolldown-binding-wasi'),
+          ]
+        : [
+            import(
+              /* @vite-ignore */ `/api/proxy/@${version}/dist/index.browser.mjs`
+            ) as Promise<typeof import('@rolldown/browser')>,
+            import(
+              /* @vite-ignore */ `/api/proxy/@${version}/dist/experimental-index.browser.mjs`
+            ) as Promise<typeof import('@rolldown/browser/experimental')>,
+            import(
+              /* @vite-ignore */ `/api/proxy/@${version}/dist/plugins-index.browser.mjs`
+            ).catch(() => null),
+            import(
+              /* @vite-ignore */ `/api/proxy/@${version}/dist/rolldown-binding.wasi-browser.js`
+            ),
+          ],
+    )
 
     loadingPhase.value = 'bundling'
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,12 @@
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
 const crossOriginHeaders = {
   'Cross-Origin-Embedder-Policy': 'require-corp',
   'Cross-Origin-Opener-Policy': 'same-origin',
 }
+
+process.env.VITE_USE_LOCAL_ROLLDOWN = '' // set to `1` to use local rolldown build for development
 
 export default defineNuxtConfig({
   modules: [
@@ -18,7 +23,16 @@ export default defineNuxtConfig({
     resolve: {
       alias: {
         path: 'pathe',
+        '@rolldown/browser/rolldown-binding-wasi': fileURLToPath(
+          new URL(
+            'rolldown-binding.wasi-browser.js',
+            import.meta.resolve('@rolldown/browser'),
+          ),
+        ),
       },
+    },
+    optimizeDeps: {
+      exclude: ['@rolldown/browser'],
     },
     build: {
       target: 'esnext',


### PR DESCRIPTION
So that we can patch rolldown and see how it works in REPL