### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: void
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: pnpm


### PR DESCRIPTION
The Deploy workflow was rejected because the org requires all actions to be pinned to a full-length commit SHA:

> The actions actions/checkout@v4, pnpm/action-setup@v4, and actions/setup-node@v4 are not allowed in rolldown/repl because all actions must be pinned to a full-length commit SHA.

This pins each action to the commit SHA of its current `v4` release, keeping the same versions:

- `actions/checkout` → `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- `pnpm/action-setup` → `b906affcce14559ad1aafd4ab0e942779e9f58b1` (v4.3.0)
- `actions/setup-node` → `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)